### PR TITLE
Avoid matching “hi” in the middle of a word

### DIFF
--- a/whoots_app.rb
+++ b/whoots_app.rb
@@ -7,7 +7,7 @@ class WhootsApp
     req = Rack::Request.new(env)
 
     case req.path
-    when /hi/
+    when /^\/hi\b/
       Rack::Response.new("Hello World!")
     when /^\/tms\/\d+\/\d+\/\d+\/\w+\/*/
       #'/tms/:z/:x/:y/:layers/*'


### PR DESCRIPTION
Tightened up the regular expression that triggers the “Hello world!” debug message.

Fixes #4.